### PR TITLE
fix typescript.js location in systemjs sample

### DIFF
--- a/systemjs/index.html
+++ b/systemjs/index.html
@@ -10,7 +10,7 @@
         System.meta['typescript'] = { format: 'global', exports: 'ts' };
         System.paths = {
             '*': '*.ts',
-            'typescript': 'node_modules/typescript/bin/typescript.js'
+            'typescript': 'node_modules/typescript/lib/typescript.js'
         }
         System.import('app').then(function(m) {
             var element = document.getElementById("content");


### PR DESCRIPTION
Currently, the systemjs sample looks for typescript.js in typescript/bin. However, it's been in typescript/lib since TypeScript 1.6. This patch fixes the issue.