### PR TITLE
use a relative url to firebase

### DIFF
--- a/angular2/index.html
+++ b/angular2/index.html
@@ -24,7 +24,7 @@
     </style>
     <script src="node_modules/systemjs/dist/system.src.js"></script>
     <script src="node_modules/angular2/bundles/angular2.dev.js"></script>
-    <script src="/firebase/firebase.js"></script>
+    <script src="firebase/firebase.js"></script>
 </head>
 <body>
     <todo-app>Loading...</todo-app>


### PR DESCRIPTION
Urls to node modules are relatives.
Url to firebase was absolute.

It was inconsistent and a source trouble when the parent folder is not use as the root of the domain.