### PR TITLE
raytracer.ts: calling rayTracer.render using canvas width and height

### DIFF
--- a/raytracer/raytracer.ts
+++ b/raytracer/raytracer.ts
@@ -271,7 +271,7 @@ function exec() {
     document.body.appendChild(canv);
     var ctx = canv.getContext("2d");
     var rayTracer = new RayTracer();
-    return rayTracer.render(defaultScene(), ctx, 256, 256);
+    return rayTracer.render(defaultScene(), ctx, canv.width, canv.height);
 }
 
 exec();


### PR DESCRIPTION
Not a bug, but It makes simpler to change the canvas size.