### PR TITLE
jspm beta latest update

### DIFF
--- a/jspm/index.html
+++ b/jspm/index.html
@@ -2,7 +2,6 @@
 <head>
     <title>Jspm sample</title>
     <script src="jspm_packages/system.src.js"></script>
-    <script src="jspm.browser.js"></script>
     <script src="jspm.config.js"></script>
 </head>
 <body>

--- a/jspm/jspm.browser.js
+++ b/jspm/jspm.browser.js
@@ -1,9 +1,0 @@
-SystemJS.config({
-  baseURL: "/",
-  paths: {
-    "*": "src/*",
-    "github:*": "jspm_packages/github/*",
-    "npm:*": "jspm_packages/npm/*",
-    "src": "src",
-  }
-});

--- a/jspm/jspm.config.js
+++ b/jspm/jspm.config.js
@@ -1,8 +1,35 @@
 SystemJS.config({
   transpiler: "plugin-typescript",
   packages: {
-    "src": {
-      "defaultExtension": "ts",
+    "app": {
+      "main": "app.ts",
+      "defaultExtension": "ts"
+    }
+  },
+  browserConfig: {
+    baseURL: "/",
+    paths: {
+      "app/": "src/",
+      "github:": "jspm_packages/github/",
+      "npm:": "jspm_packages/npm/"
+    }
+  },
+  devConfig: {
+    "map": {
+      "plugin-typescript": "github:frankwallis/plugin-typescript@4.0.6",
+      "os": "github:jspm/nodelibs-os@0.2.0-alpha"
+    },
+    "packages": {
+      "github:frankwallis/plugin-typescript@4.0.6": {
+        "map": {
+          "typescript": "npm:typescript@1.8.10"
+        }
+      },
+      "github:jspm/nodelibs-os@0.2.0-alpha": {
+        "map": {
+          "os-browserify": "npm:os-browserify@0.2.1"
+        }
+      }
     }
   }
 });
@@ -14,47 +41,10 @@ SystemJS.config({
     "github:*/*.json"
   ],
   map: {
-    "buffer": "github:jspm/nodelibs-buffer@0.2.0-alpha",
-    "child_process": "github:jspm/nodelibs-child_process@0.2.0-alpha",
-    "core-js": "npm:core-js@0.9.18",
+    "core-js": "npm:core-js@2.4.0",
     "fs": "github:jspm/nodelibs-fs@0.2.0-alpha",
-    "os": "github:jspm/nodelibs-os@0.2.0-alpha",
     "path": "github:jspm/nodelibs-path@0.2.0-alpha",
-    "plugin-typescript": "github:frankwallis/plugin-typescript@4.0.6",
-    "process": "github:jspm/nodelibs-process@0.2.0-alpha",
-    "readline": "github:jspm/nodelibs-readline@0.2.0-alpha",
-    "typescript": "npm:typescript@1.5.3"
+    "process": "github:jspm/nodelibs-process@0.2.0-alpha"
   },
-  packages: {
-    "github:frankwallis/plugin-typescript@4.0.6": {
-      "map": {
-        "typescript": "npm:typescript@1.8.10"
-      }
-    },
-    "github:jspm/nodelibs-buffer@0.2.0-alpha": {
-      "map": {
-        "buffer-browserify": "npm:buffer@4.5.1"
-      }
-    },
-    "github:jspm/nodelibs-os@0.2.0-alpha": {
-      "map": {
-        "os-browserify": "npm:os-browserify@0.2.1"
-      }
-    },
-    "npm:buffer@4.5.1": {
-      "map": {
-        "base64-js": "npm:base64-js@1.1.2",
-        "ieee754": "npm:ieee754@1.1.6",
-        "isarray": "npm:isarray@1.0.0"
-      }
-    },
-    "npm:core-js@0.9.18": {
-      "map": {
-        "systemjs-json": "github:systemjs/plugin-json@0.1.0"
-      }
-    },
-    "npm:typescript@1.5.3": {
-      "map": {}
-    }
-  }
+  packages: {}
 });

--- a/jspm/package.json
+++ b/jspm/package.json
@@ -1,19 +1,29 @@
 {
   "jspm": {
-    "directories": {},
     "dependencies": {
-      "core-js": "npm:core-js@^0.9.4"
+      "core-js": "npm:core-js@^2.4.0"
     },
     "devDependencies": {
-      "buffer": "github:jspm/nodelibs-buffer@^0.2.0-alpha",
-      "child_process": "github:jspm/nodelibs-child_process@^0.2.0-alpha",
-      "fs": "github:jspm/nodelibs-fs@^0.2.0-alpha",
       "os": "github:jspm/nodelibs-os@^0.2.0-alpha",
+      "plugin-typescript": "github:frankwallis/plugin-typescript@^4.0.6"
+    },
+    "peerDependencies": {
+      "fs": "github:jspm/nodelibs-fs@^0.2.0-alpha",
       "path": "github:jspm/nodelibs-path@^0.2.0-alpha",
-      "plugin-typescript": "github:frankwallis/plugin-typescript@^4.0.6",
-      "process": "github:jspm/nodelibs-process@^0.2.0-alpha",
-      "readline": "github:jspm/nodelibs-readline@^0.2.0-alpha",
-      "typescript": "npm:typescript@1.8.10"
+      "process": "github:jspm/nodelibs-process@^0.2.0-alpha"
+    },
+    "overrides": {
+      "npm:typescript@1.8.10": {
+        "browser": {},
+        "map": {
+          "buffer": "@empty",
+          "child_process": "@empty",
+          "fs": "@empty",
+          "path": "@empty",
+          "process": "@empty",
+          "readline": "@empty"
+        }
+      }
     }
   }
 }

--- a/jspm/src/app.ts
+++ b/jspm/src/app.ts
@@ -1,4 +1,4 @@
-import { Greeter } from 'greeter'
+import { Greeter } from './greeter'
 
 export function main(el: HTMLElement): void {
     let greeter = new Greeter(el);


### PR DESCRIPTION
This updates the jspm sample configuration to the latest beta version of jspm. The base-level wildcard is not supported in the latest beta so this was causing the sample to break.