### PR TITLE
typings config refactor needed by latest definition manager v >=1.0.0

### DIFF
--- a/react-flux-babel-karma/src/tsconfig.json
+++ b/react-flux-babel-karma/src/tsconfig.json
@@ -1,9 +1,9 @@
 {
     "compileOnSave": false,
     "filesGlob": [
-        "../typings/browser/**/*.*.ts",
-        "!../typings/browser/ambient/jasmine/index.d.ts",
-        "!../typings/browser/ambient/react-addons-test-utils/index.d.ts",
+        "../typings/globals/**/*.*.ts",
+        "!../typings/globals/jasmine/index.d.ts",
+        "!../typings/globals/react-addons-test-utils/index.d.ts",
         "**/*.{ts,tsx}"
     ],
     "compilerOptions": {
@@ -15,10 +15,10 @@
         "sourceMap": true
     },
     "files": [
-        "../typings/browser/ambient/react/index.d.ts",
-        "../typings/browser/ambient/react-dom/index.d.ts",
-        "../typings/browser/ambient/flux/index.d.ts",
-        "../typings/browser/ambient/node/index.d.ts",
+        "../typings/globals/react/index.d.ts",
+        "../typings/globals/react-dom/index.d.ts",
+        "../typings/globals/flux/index.d.ts",
+        "../typings/globals/node/index.d.ts",
         "actions/GreetingActions.ts",
         "components/App.tsx",
         "components/Greeting.tsx",

--- a/react-flux-babel-karma/test/tsconfig.json
+++ b/react-flux-babel-karma/test/tsconfig.json
@@ -2,7 +2,7 @@
     "compileOnSave": false,
     "filesGlob": [
         "**/*.{ts,tsx}",
-        "../typings/browser/**/*.*.ts"
+        "../typings/globals/**/*.*.ts"
     ],
     "compilerOptions": {
         "jsx": "preserve",
@@ -13,12 +13,12 @@
         "sourceMap": true
     },
     "files": [
-        "../typings/browser/ambient/react/index.d.ts",
-        "../typings/browser/ambient/react-dom/index.d.ts",
-        "../typings/browser/ambient/react-addons-test-utils/index.d.ts",
-        "../typings/browser/ambient/flux/index.d.ts",
-        "../typings/browser/ambient/jasmine/index.d.ts",
-        "../typings/browser/ambient/node/index.d.ts",
+        "../typings/globals/react/index.d.ts",
+        "../typings/globals/react-dom/index.d.ts",
+        "../typings/globals/react-addons-test-utils/index.d.ts",
+        "../typings/globals/flux/index.d.ts",
+        "../typings/globals/jasmine/index.d.ts",
+        "../typings/globals/node/index.d.ts",
         "components/App.tests.tsx",
         "components/Greeting.tests.tsx",
         "components/WhoToGreet.tests.tsx",

--- a/react-flux-babel-karma/typings.json
+++ b/react-flux-babel-karma/typings.json
@@ -1,7 +1,7 @@
 {
   "name": "es6-babel-react-flux-karma",
   "version": false,
-  "ambientDependencies": {
+  "globalDependencies": {
     "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#bcd5761826eb567876c197ccc6a87c4d05731054",
     "flux": "github:DefinitelyTyped/DefinitelyTyped/flux/flux.d.ts#bcd5761826eb567876c197ccc6a87c4d05731054",
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#bcd5761826eb567876c197ccc6a87c4d05731054",


### PR DESCRIPTION
Latest Typings version no longer uses ambientDependencies and has been renamed as globalDependencies. see https://github.com/typings/core/releases/tag/v1.0.0

This PR has been made to fix react-flux-babel-karma example after a fresh `npm install -g typings`