### PR TITLE
Update raytracer.ts

### DIFF
--- a/raytracer/raytracer.ts
+++ b/raytracer/raytracer.ts
@@ -244,7 +244,7 @@ class RayTracer {
                 var color = this.traceRay({ start: scene.camera.pos, dir: getPoint(x, y, scene.camera) }, scene, 0);
                 var c = Color.toDrawingColor(color);
                 ctx.fillStyle = "rgb(" + String(c.r) + ", " + String(c.g) + ", " + String(c.b) + ")";
-                ctx.fillRect(x, y, x + 1, y + 1);
+                ctx.fillRect(x, y, 1, 1);
             }
         }
     }


### PR DESCRIPTION
`ctx.fillRect()` last 2 args should be width and height (not x2, y2)
https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillRect

will this fix https://www.typescriptlang.org/examples/raytracer.ts which is used in https://www.typescriptlang.org/play/index.html too?