### PR TITLE
Remove jQuery dependency in JSX demo to simplify example

### DIFF
--- a/jsx/package.json
+++ b/jsx/package.json
@@ -28,12 +28,10 @@
     "devDependencies": {
         "typescript": "latest",
         "http-server": "0.8.0",
-        "@types/jquery": "^2",
         "@types/react-dom": "^15",
         "@types/react": "^15"
     },
     "dependencies": {
-        "jquery": "^3.3.1",
         "react": "^15.6.1",
         "react-dom": "^15.6.1",
         "requirejs": "^2.1.20"

--- a/jsx/src/app.tsx
+++ b/jsx/src/app.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import * as $ from 'jquery';
 import {Greeter as Greetifier, GreeterProps as GreeterProps} from 'greeter';
 
 function getRandomGreeting() {
@@ -12,11 +11,11 @@ function getRandomGreeting() {
     }
 }
 
-$(() => {
+(() => {
     let props: GreeterProps = {
         whomToGreet: 'world!',
     };
 
     ReactDOM.render(<Greetifier {...props} greeting={getRandomGreeting} />, $('#output').get(0));
-});
+})();
 


### PR DESCRIPTION
In pursuit of keeping examples simple and understandable, I removed the jQuery dependency from the JSX example, as many newer developers may not have experience with it.